### PR TITLE
implement non-strict-alternative to valueOf factory method

### DIFF
--- a/src/main/java/com/github/zafarkhaja/semver/Version.java
+++ b/src/main/java/com/github/zafarkhaja/semver/Version.java
@@ -266,6 +266,16 @@ public class Version implements Comparable<Version> {
     }
 
     /**
+     * Creates a new instance of {@code Version} leniently parsing the version-core only.
+     *
+     * @param version the version string to parse
+     * @return a new instance of the {@code Version} class
+     */
+    public static Version valueOfLenient(String version) {
+        return new Version(VersionParser.parseVersionCore(version));
+    }
+
+    /**
      * Creates a new instance of {@code Version}
      * for the specified version numbers.
      *

--- a/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
@@ -376,6 +376,14 @@ public class VersionTest {
             Version v2 = Version.valueOf("2.3.7-beta");
             assertTrue(v1.equals(v2));
         }
+
+        @Test
+        public void shouldIgnoreMoreThanFourDigitsInLenientVersion() {
+            Version fourDigitVersion = Version.valueOfLenient("2.3.7.123");
+            Version semverValidVersion = Version.valueOf("2.3.7");
+            assertTrue(fourDigitVersion.equals(semverValidVersion));
+        }
+
     }
 
     public static class HashCodeMethodTest {


### PR DESCRIPTION
in essence exposing VersionParser::parseVersionCore()

Reason:

Input version-strings might not always be valid semver style even if i want a valid semver in the end. 0.7.2 wasn't as strict in that regard, so it'd be nice to have a lenient parsing version that ignores everything apart from the parseable version-core (NormalVersion).