### PR TITLE
Support wider version numbers.

### DIFF
--- a/src/main/java/com/github/zafarkhaja/semver/NormalVersion.java
+++ b/src/main/java/com/github/zafarkhaja/semver/NormalVersion.java
@@ -36,17 +36,17 @@ class NormalVersion implements Comparable<NormalVersion> {
     /**
      * The major version number.
      */
-    private final int major;
+    private final long major;
 
     /**
      * The minor version number.
      */
-    private final int minor;
+    private final long minor;
 
     /**
      * The patch version number.
      */
-    private final int patch;
+    private final long patch;
 
     /**
      * Constructs a {@code NormalVersion} with the
@@ -57,7 +57,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      * @param patch the patch version number
      * @throws IllegalArgumentException if one of the version numbers is a negative integer
      */
-    NormalVersion(int major, int minor, int patch) {
+    NormalVersion(long major, long minor, long patch) {
         if (major < 0 || minor < 0 || patch < 0) {
             throw new IllegalArgumentException(
                 "Major, minor and patch versions MUST be non-negative integers."
@@ -73,7 +73,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      *
      * @return the major version number
      */
-    int getMajor() {
+    long getMajor() {
         return major;
     }
 
@@ -82,7 +82,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      *
      * @return the minor version number
      */
-    int getMinor() {
+    long getMinor() {
         return minor;
     }
 
@@ -91,7 +91,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      *
      * @return the patch version number
      */
-    int getPatch() {
+    long getPatch() {
         return patch;
     }
 
@@ -127,14 +127,17 @@ class NormalVersion implements Comparable<NormalVersion> {
      */
     @Override
     public int compareTo(NormalVersion other) {
-        int result = major - other.major;
+        long result = major - other.major;
         if (result == 0) {
             result = minor - other.minor;
             if (result == 0) {
                 result = patch - other.patch;
+                if (result == 0) {
+                    return 0;
+                }
             }
         }
-        return result;
+        return (result < 0) ? -1 : 1;
     }
 
     /**
@@ -157,9 +160,9 @@ class NormalVersion implements Comparable<NormalVersion> {
     @Override
     public int hashCode() {
         int hash = 17;
-        hash = 31 * hash + major;
-        hash = 31 * hash + minor;
-        hash = 31 * hash + patch;
+        hash = 31 * hash + new Long(major).hashCode();
+        hash = 31 * hash + new Long(minor).hashCode();
+        hash = 31 * hash + new Long(patch).hashCode();
         return hash;
     }
 

--- a/src/main/java/com/github/zafarkhaja/semver/Version.java
+++ b/src/main/java/com/github/zafarkhaja/semver/Version.java
@@ -463,7 +463,7 @@ public class Version implements Comparable<Version> {
      *
      * @return the major version number
      */
-    public int getMajorVersion() {
+    public long getMajorVersion() {
         return normal.getMajor();
     }
 
@@ -472,7 +472,7 @@ public class Version implements Comparable<Version> {
      *
      * @return the minor version number
      */
-    public int getMinorVersion() {
+    public long getMinorVersion() {
         return normal.getMinor();
     }
 
@@ -481,7 +481,7 @@ public class Version implements Comparable<Version> {
      *
      * @return the patch version number
      */
-    public int getPatchVersion() {
+    public long getPatchVersion() {
         return normal.getPatch();
     }
 

--- a/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
+++ b/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
@@ -282,11 +282,11 @@ class VersionParser implements Parser<Version> {
      * @return a valid normal version object
      */
     private NormalVersion parseVersionCore() {
-        int major = Integer.parseInt(numericIdentifier());
+        long major = Long.parseLong(numericIdentifier());
         consumeNextCharacter(DOT);
-        int minor = Integer.parseInt(numericIdentifier());
+        long minor = Long.parseLong(numericIdentifier());
         consumeNextCharacter(DOT);
-        int patch = Integer.parseInt(numericIdentifier());
+        long patch = Long.parseLong(numericIdentifier());
         return new NormalVersion(major, minor, patch);
     }
 

--- a/src/test/java/com/github/zafarkhaja/semver/VersionParserTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionParserTest.java
@@ -124,4 +124,15 @@ public class VersionParserTest {
             fail("Should raise error for illegal input string");
         }
     }
+
+    @Test
+    public void shouldParseLongVersionNumbers() {
+        NormalVersion version
+            = VersionParser.parseVersionCore("9007199254740991"
+                                             + ".9007199254740991"
+                                             + ".9007199254740991");
+        assertEquals(new NormalVersion(9007199254740991l,
+                                       9007199254740991l,
+                                       9007199254740991l), version);
+    }
 }


### PR DESCRIPTION
#### What does this PR do?

Swaps `int` to `long` in `NormalVersion`. Updates parsing to handle the larger possible numbers.

Added a test to `VersionParserTest.java` to cover this scenario.
#### How should this be manually tested?

```
> VersionParser.parseVersionCore("9007199254740991.9007199254740991.9007199254740991")
==>9007199254740991.9007199254740991.9007199254740991
> new VersionParser('9007199254740991.9007199254740991.9007199254740991').parse(null)
==>9007199254740991.9007199254740991.9007199254740991
> Version.valueOf('9007199254740991.9007199254740991.9007199254740991')
==>9007199254740991.9007199254740991.9007199254740991
> new NormalVersion(9007199254740991, 9007199254740991, 9007199254740991)
==>9007199254740991.9007199254740991.9007199254740991
```
#### Any background context you want to provide?

Improves some compatibility with `node-semver`. Node supports version numbers larger\* than can be fitted into an `int`. The version given in the test that I added (`9007199254740991.9007199254740991.9007199254740991`) is a real version number found in the wild and was in a data-set I was processing which necessitated this change.

_*`node-semver` also has an upper limit on version numbers due to max safest number that can be represented exactly by javascript's `Number` type (`Number.MAX_SAFE_INTEGER==9007199254740991`), but that arbitrary limit is ignored here. It's probably no coincidence that it is the same value as the number above that I found in the wild. I have also found some version numbers even larger in my dataset from before node and npm imposing a limit_
