### PR TITLE
Optionally leave out patch version and only use major.minor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.github.zafarkhaja</groupId>
   <artifactId>java-semver</artifactId>
-  <version>0.9.0</version>
+  <version>0.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Java SemVer</name>

--- a/src/main/java/com/github/zafarkhaja/semver/NormalVersion.java
+++ b/src/main/java/com/github/zafarkhaja/semver/NormalVersion.java
@@ -49,6 +49,11 @@ class NormalVersion implements Comparable<NormalVersion> {
     private final int patch;
 
     /**
+     * True if patch versions not used
+     */
+	private final boolean hasPatchVersion;
+
+    /**
      * Constructs a {@code NormalVersion} with the
      * major, minor and patch version numbers.
      *
@@ -66,6 +71,28 @@ class NormalVersion implements Comparable<NormalVersion> {
         this.major = major;
         this.minor = minor;
         this.patch = patch;
+        this.hasPatchVersion = true;
+    }
+
+    /**
+     * Constructs a {@code NormalVersion} with the
+     * major, minor and patch version numbers.
+     *
+     * @param major the major version number
+     * @param minor the minor version number
+     * @param patch the patch version number
+     * @throws IllegalArgumentException if one of the version numbers is a negative integer
+     */
+    NormalVersion(int major, int minor) {
+        if (major < 0 || minor < 0) {
+            throw new IllegalArgumentException(
+                "Major and minor versions MUST be non-negative integers."
+            );
+        }
+        this.major = major;
+        this.minor = minor;
+        this.patch = 0;
+        this.hasPatchVersion = false;
     }
 
     /**
@@ -92,7 +119,14 @@ class NormalVersion implements Comparable<NormalVersion> {
      * @return the patch version number
      */
     int getPatch() {
+        checkIfPatchVersionEnabled();
         return patch;
+    }
+
+    private void checkIfPatchVersionEnabled() {
+        if (!hasPatchVersion) {
+            throw new IllegalStateException("This version has no patch version");
+        }
     }
 
     /**
@@ -101,7 +135,11 @@ class NormalVersion implements Comparable<NormalVersion> {
      * @return a new instance of the {@code NormalVersion} class
      */
     NormalVersion incrementMajor() {
-        return new NormalVersion(major + 1, 0, 0);
+        if (hasPatchVersion) {
+            return new NormalVersion(major + 1, 0, 0);
+        } else {
+            return new NormalVersion(major + 1, 0);
+        }
     }
 
     /**
@@ -110,7 +148,11 @@ class NormalVersion implements Comparable<NormalVersion> {
      * @return a new instance of the {@code NormalVersion} class
      */
     NormalVersion incrementMinor() {
-        return new NormalVersion(major, minor + 1, 0);
+        if (hasPatchVersion) {
+            return new NormalVersion(major, minor + 1, 0);
+        } else {
+            return new NormalVersion(major, minor + 1);
+        }
     }
 
     /**
@@ -119,6 +161,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      * @return a new instance of the {@code NormalVersion} class
      */
     NormalVersion incrementPatch() {
+        checkIfPatchVersionEnabled();
         return new NormalVersion(major, minor, patch + 1);
     }
 
@@ -159,7 +202,9 @@ class NormalVersion implements Comparable<NormalVersion> {
         int hash = 17;
         hash = 31 * hash + major;
         hash = 31 * hash + minor;
-        hash = 31 * hash + patch;
+        if (hasPatchVersion) {
+            hash = 31 * hash + patch;
+        }
         return hash;
     }
 
@@ -174,6 +219,10 @@ class NormalVersion implements Comparable<NormalVersion> {
      */
     @Override
     public String toString() {
-        return String.format("%d.%d.%d", major, minor, patch);
+        if (hasPatchVersion) {
+            return String.format("%d.%d.%d", major, minor, patch);
+        } else {
+            return String.format("%d.%d", major, minor);
+        }
     }
 }

--- a/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
+++ b/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
@@ -276,6 +276,7 @@ class VersionParser implements Parser<Version> {
      * <pre>
      * {@literal
      * <version core> ::= <major> "." <minor> "." <patch>
+     *                  | <major> "." <minor>
      * }
      * </pre>
      *
@@ -285,9 +286,13 @@ class VersionParser implements Parser<Version> {
         int major = Integer.parseInt(numericIdentifier());
         consumeNextCharacter(DOT);
         int minor = Integer.parseInt(numericIdentifier());
-        consumeNextCharacter(DOT);
-        int patch = Integer.parseInt(numericIdentifier());
-        return new NormalVersion(major, minor, patch);
+        if (chars.positiveLookahead(DOT)) {
+            consumeNextCharacter(DOT);
+            int patch = Integer.parseInt(numericIdentifier());
+            return new NormalVersion(major, minor, patch);
+        } else {
+            return new NormalVersion(major, minor);
+        }
     }
 
     /**

--- a/src/test/java/com/github/zafarkhaja/semver/NormalVersionTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/NormalVersionTest.java
@@ -53,14 +53,18 @@ public class NormalVersionTest {
 
         @Test
         public void shouldAcceptOnlyNonNegativeMajorMinorAndPatchVersions() {
-            int[][] invalidVersions = {{-1, 2, 3}, {1, -2, 3}, {1, 2, -3}};
+            int[][] invalidVersions = {{-1, 2, 3}, {1, -2, 3}, {1, 2, -3}, {-1,2}, {1,-1}};
             for (int[] versionParts : invalidVersions) {
                 try {
-                    new NormalVersion(
-                        versionParts[0],
-                        versionParts[1],
-                        versionParts[2]
-                    );
+                    if (versionParts.length == 3) {
+                        new NormalVersion(
+                            versionParts[0],
+                            versionParts[1],
+                            versionParts[2]
+                        );
+                    } else {
+                        new NormalVersion(versionParts[0], versionParts[1]);
+                    }
                 } catch (IllegalArgumentException e) {
                     continue;
                 }
@@ -104,6 +108,14 @@ public class NormalVersionTest {
             assertTrue(0 < v.compareTo(new NormalVersion(0, 2, 3)));
             assertTrue(0 == v.compareTo(new NormalVersion(1, 2, 3)));
             assertTrue(0 > v.compareTo(new NormalVersion(1, 2, 4)));
+        }
+
+        @Test
+        public void mustCompareMajorMinorWithoutPatchNumerically() {
+            NormalVersion v = new NormalVersion(1, 2);
+            assertTrue(0 < v.compareTo(new NormalVersion(0, 2)));
+            assertTrue(0 == v.compareTo(new NormalVersion(1, 2)));
+            assertTrue(0 > v.compareTo(new NormalVersion(1, 3)));
         }
 
         @Test

--- a/src/test/java/com/github/zafarkhaja/semver/ParserErrorHandlingTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/ParserErrorHandlingTest.java
@@ -84,7 +84,6 @@ public class ParserErrorHandlingTest {
             { "1",            null, 1,  new CharType[] { DOT } },
             { "1 ",           ' ',  1,  new CharType[] { DOT } },
             { "1.",           null, 2,  new CharType[] { DIGIT } },
-            { "1.2",          null, 3,  new CharType[] { DOT } },
             { "1.2.",         null, 4,  new CharType[] { DIGIT } },
             { "a.b.c",        'a',  0,  new CharType[] { DIGIT } },
             { "1.b.c",        'b',  2,  new CharType[] { DIGIT } },

--- a/src/test/java/com/github/zafarkhaja/semver/VersionParserTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionParserTest.java
@@ -39,6 +39,12 @@ public class VersionParserTest {
     }
 
     @Test
+    public void optionalPatchVersionShouldDefaultToZero() {
+        NormalVersion version = VersionParser.parseVersionCore("1.0");
+        assertEquals(new NormalVersion(1, 0, 0), version);
+    }
+
+    @Test
     public void shouldRaiseErrorIfNumericIdentifierHasLeadingZeroes() {
         try {
             VersionParser.parseVersionCore("01.1.0");

--- a/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
@@ -70,6 +70,24 @@ public class VersionTest {
         }
 
         @Test
+        public void shouldIgnorePatchIfNotGivenWhenDeterminingVersionPrecedence() {
+            Version v1 = Version.valueOf("1.3");
+            Version v2 = Version.valueOf("1.3");
+            assertTrue(0 == v1.compareTo(v2));
+        }
+
+        @Test
+        public void shouldAssumePatchZeroIfNotGivenWhenDeterminingVersionPrecedence() {
+            Version v1 = Version.valueOf("1.3");
+            Version v2 = Version.valueOf("1.3.7");
+            Version v3 = Version.valueOf("1.3.0");
+            assertTrue(0 == v1.compareTo(v3));
+            assertTrue(0 == v3.compareTo(v1));
+            assertTrue(0 > v1.compareTo(v2));
+            assertTrue(0 < v2.compareTo(v1));
+        }
+
+        @Test
         public void shouldHaveGreaterThanMethodReturningBoolean() {
             Version v1 = Version.valueOf("2.3.7");
             Version v2 = Version.valueOf("1.3.7");


### PR DESCRIPTION
It would be useful if patch version was optional, i.e. versions could be 1.3, 1.3-RC1 etc. I'm using the axion-release-plugin which uses jsemver, and this pull request making patch version optional greatly simplifies configuration of release versions, i.e. serializing/deserializing to take care of adding/removing ".0".
