### PR TITLE
Allow for long versions.

### DIFF
--- a/src/main/java/com/github/zafarkhaja/semver/NormalVersion.java
+++ b/src/main/java/com/github/zafarkhaja/semver/NormalVersion.java
@@ -36,17 +36,17 @@ class NormalVersion implements Comparable<NormalVersion> {
     /**
      * The major version number.
      */
-    private final int major;
+    private final long major;
 
     /**
      * The minor version number.
      */
-    private final int minor;
+    private final long minor;
 
     /**
      * The patch version number.
      */
-    private final int patch;
+    private final long patch;
 
     /**
      * Constructs a {@code NormalVersion} with the
@@ -57,7 +57,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      * @param patch the patch version number
      * @throws IllegalArgumentException if one of the version numbers is a negative integer
      */
-    NormalVersion(int major, int minor, int patch) {
+    NormalVersion(long major, long minor, long patch) {
         if (major < 0 || minor < 0 || patch < 0) {
             throw new IllegalArgumentException(
                 "Major, minor and patch versions MUST be non-negative integers."
@@ -73,7 +73,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      *
      * @return the major version number
      */
-    int getMajor() {
+    long getMajor() {
         return major;
     }
 
@@ -82,7 +82,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      *
      * @return the minor version number
      */
-    int getMinor() {
+    long getMinor() {
         return minor;
     }
 
@@ -91,7 +91,7 @@ class NormalVersion implements Comparable<NormalVersion> {
      *
      * @return the patch version number
      */
-    int getPatch() {
+    long getPatch() {
         return patch;
     }
 
@@ -127,14 +127,17 @@ class NormalVersion implements Comparable<NormalVersion> {
      */
     @Override
     public int compareTo(NormalVersion other) {
-        int result = major - other.major;
+        long result = major - other.major;
         if (result == 0) {
             result = minor - other.minor;
             if (result == 0) {
                 result = patch - other.patch;
+                if (result == 0) {
+                    return 0;
+                }
             }
         }
-        return result;
+        return result < 0 ? -1 : 1;
     }
 
     /**
@@ -156,11 +159,11 @@ class NormalVersion implements Comparable<NormalVersion> {
      */
     @Override
     public int hashCode() {
-        int hash = 17;
+        long hash = 17L;
         hash = 31 * hash + major;
         hash = 31 * hash + minor;
         hash = 31 * hash + patch;
-        return hash;
+        return (int) hash;
     }
 
     /**

--- a/src/main/java/com/github/zafarkhaja/semver/Version.java
+++ b/src/main/java/com/github/zafarkhaja/semver/Version.java
@@ -463,7 +463,7 @@ public class Version implements Comparable<Version> {
      *
      * @return the major version number
      */
-    public int getMajorVersion() {
+    public long getMajorVersion() {
         return normal.getMajor();
     }
 
@@ -472,7 +472,7 @@ public class Version implements Comparable<Version> {
      *
      * @return the minor version number
      */
-    public int getMinorVersion() {
+    public long getMinorVersion() {
         return normal.getMinor();
     }
 
@@ -481,7 +481,7 @@ public class Version implements Comparable<Version> {
      *
      * @return the patch version number
      */
-    public int getPatchVersion() {
+    public long getPatchVersion() {
         return normal.getPatch();
     }
 

--- a/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
+++ b/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
@@ -283,11 +283,11 @@ class VersionParser implements Parser<Version> {
      * @return a valid normal version object
      */
     private NormalVersion parseVersionCore() {
-        int major = Integer.parseInt(numericIdentifier());
+        long major = Long.parseLong(numericIdentifier());
         consumeNextCharacter(DOT);
-        int minor = Integer.parseInt(numericIdentifier());
+        long minor = Long.parseLong(numericIdentifier());
         consumeNextCharacter(DOT);
-        int patch = Integer.parseInt(numericIdentifier());
+        long patch = Long.parseLong(numericIdentifier());
         return new NormalVersion(major, minor, patch);
     }
 

--- a/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
@@ -26,9 +26,14 @@ package com.github.zafarkhaja.semver;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
+
 import static com.github.zafarkhaja.semver.expr.CompositeExpression.Helper.gte;
 import static com.github.zafarkhaja.semver.expr.CompositeExpression.Helper.lt;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  *
@@ -331,6 +336,15 @@ public class VersionTest {
             Version v3 = Version.valueOf("1.2.3");
             assertTrue(v1.isMinorVersionCompatible(v2));
             assertFalse(v1.isMinorVersionCompatible(v3));
+        }
+
+        @Test
+        public void shouldParseLongPatchVersionCorrectly() {
+            try {
+                Version.valueOf("3.2.1477710197605");
+            } catch (NumberFormatException e) {
+                fail("Incorrectly got number format exception. " + e.getLocalizedMessage());
+            }
         }
     }
 


### PR DESCRIPTION
Our tests use currentTimeMilliseconds in the patch version to check for longer version. It will be convenient if we can use long versions, as they are accepted in ordinary npm-registries.
