### PR TITLE
Fixed expression language to match syntax from https://docs.npmjs.com…

### DIFF
--- a/src/main/java/com/github/zafarkhaja/semver/expr/CompositeExpression.java
+++ b/src/main/java/com/github/zafarkhaja/semver/expr/CompositeExpression.java
@@ -239,7 +239,9 @@ public class CompositeExpression implements Expression {
      * @return this {@code CompositeExpression}
      */
     public CompositeExpression or(Expression expr) {
-        exprTree = new Or(exprTree, expr);
+        if (expr != null) {
+            exprTree = new Or(exprTree, expr);
+        }
         return this;
     }
 

--- a/src/main/java/com/github/zafarkhaja/semver/expr/Lexer.java
+++ b/src/main/java/com/github/zafarkhaja/semver/expr/Lexer.java
@@ -24,6 +24,7 @@
 package com.github.zafarkhaja.semver.expr;
 
 import com.github.zafarkhaja.semver.util.Stream;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -57,14 +58,17 @@ class Lexer {
             LESS("<(?!=)"),
             LESS_EQUAL("<="),
             TILDE("~"),
-            WILDCARD("[\\*xX]"),
+            STAR_WILDCARD("\\*"),
+            X_WILDCARD("[xX]"),
             CARET("\\^"),
-            AND("&"),
-            OR("\\|"),
-            NOT("!(?!=)"),
-            LEFT_PAREN("\\("),
-            RIGHT_PAREN("\\)"),
+//            AND("&(&)?"),
+            OR("\\s*\\|\\|\\s*"),
+//            NOT("!(?!=)"),
+//            LEFT_PAREN("\\("),
+//            RIGHT_PAREN("\\)"),
             WHITESPACE("\\s+"),
+            ALPHA("[A-Za-z]+"),
+            PLUS("\\+"),
             EOI("?!");
 
             /**
@@ -124,8 +128,8 @@ class Lexer {
          * Constructs a {@code Token} instance
          * with the type, lexeme and position.
          *
-         * @param type the type of this token
-         * @param lexeme the lexeme of this token
+         * @param type     the type of this token
+         * @param lexeme   the lexeme of this token
          * @param position the position of this token
          */
         Token(Type type, String lexeme, int position) {
@@ -147,9 +151,9 @@ class Lexer {
             }
             Token token = (Token) other;
             return
-                type.equals(token.type) &&
-                lexeme.equals(token.lexeme) &&
-                position == token.position;
+                    type.equals(token.type) &&
+                            lexeme.equals(token.lexeme) &&
+                            position == token.position;
         }
 
         /**
@@ -172,9 +176,9 @@ class Lexer {
         @Override
         public String toString() {
             return String.format(
-                "%s(%s) at position %d",
-                type.name(),
-                lexeme, position
+                    "%s(%s) at position %d",
+                    type.name(),
+                    lexeme, position
             );
         }
     }
@@ -203,13 +207,13 @@ class Lexer {
                 if (matcher.find()) {
                     matched = true;
                     input = matcher.replaceFirst("");
-                    if (tokenType != Token.Type.WHITESPACE) {
+//                    if (tokenType != Token.Type.WHITESPACE) {
                         tokens.add(new Token(
                             tokenType,
                             matcher.group(),
                             tokenPos
                         ));
-                    }
+//                    }
                     tokenPos += matcher.end();
                     break;
                 }

--- a/src/main/java/com/github/zafarkhaja/semver/expr/LexerException.java
+++ b/src/main/java/com/github/zafarkhaja/semver/expr/LexerException.java
@@ -49,6 +49,10 @@ public class LexerException extends ParseException {
         this.expr = expr;
     }
 
+    public String getExpr() {
+        return expr;
+    }
+
     /**
      * Returns the string representation of this exception.
      *

--- a/src/test/java/com/github/zafarkhaja/semver/expr/ExpressionParserTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/expr/ExpressionParserTest.java
@@ -145,63 +145,45 @@ public class ExpressionParserTest {
     @Test
     public void shouldParseMultipleRangesJoinedWithAnd() {
         ExpressionParser parser = new ExpressionParser(new Lexer());
-        Expression and = parser.parse(">=1.0.0 & <2.0.0");
+        Expression and = parser.parse(">=1.0.0  <2.0.0");
         assertTrue(and.interpret(Version.valueOf("1.2.3")));
         assertFalse(and.interpret(Version.valueOf("3.2.1")));
+        and = parser.parse(">=1.8.0  <2.1.0 || >=1.9.0-dev || >=2.0.0-dev || || >=2.1.0-dev");
+        assertTrue(and.interpret(Version.valueOf("1.9.0")));
     }
 
     @Test
     public void shouldParseMultipleRangesJoinedWithOr() {
         ExpressionParser parser = new ExpressionParser(new Lexer());
-        Expression or = parser.parse("1.* | =2.0.0");
+        Expression or = parser.parse("1.* || =2.0.0");
         assertTrue(or.interpret(Version.valueOf("1.2.3")));
         assertFalse(or.interpret(Version.valueOf("2.1.0")));
     }
 
     @Test
-    public void shouldParseParenthesizedExpression() {
-        ExpressionParser parser = new ExpressionParser(new Lexer());
-        Expression expr = parser.parse("(1)");
-        assertTrue(expr.interpret(Version.valueOf("1.2.3")));
-        assertFalse(expr.interpret(Version.valueOf("2.0.0")));
-    }
-
-    @Test
-    public void shouldParseExpressionWithMultipleParentheses() {
-        ExpressionParser parser = new ExpressionParser(new Lexer());
-        Expression expr = parser.parse("((1))");
-        assertTrue(expr.interpret(Version.valueOf("1.2.3")));
-        assertFalse(expr.interpret(Version.valueOf("2.0.0")));
-    }
-
-    @Test
-    public void shouldParseNotExpression() {
-        ExpressionParser parser = new ExpressionParser(new Lexer());
-        Expression not1 = parser.parse("!(1)");
-        assertTrue(not1.interpret(Version.valueOf("2.0.0")));
-        assertFalse(not1.interpret(Version.valueOf("1.2.3")));
-        Expression not2 = parser.parse("0.* & !(>=1 & <2)");
-        assertTrue(not2.interpret(Version.valueOf("0.5.0")));
-        assertFalse(not2.interpret(Version.valueOf("1.0.1")));
-        Expression not3 = parser.parse("!(>=1 & <2) & >=2");
-        assertTrue(not3.interpret(Version.valueOf("2.0.0")));
-        assertFalse(not3.interpret(Version.valueOf("1.2.3")));
-    }
-
-    @Test
-    public void shouldRespectPrecedenceWhenUsedWithParentheses() {
-        ExpressionParser parser = new ExpressionParser(new Lexer());
-        Expression expr1 = parser.parse("(~1.0 & <2.0) | >2.0");
-        assertTrue(expr1.interpret(Version.valueOf("2.5.0")));
-        Expression expr2 = parser.parse("~1.0 & (<2.0 | >2.0)");
-        assertFalse(expr2.interpret(Version.valueOf("2.5.0")));
-    }
-
-    @Test
     public void shouldParseComplexExpressions() {
         ExpressionParser parser = new ExpressionParser(new Lexer());
-        Expression expr = parser.parse("((>=1.0.1 & <2) | (>=3.0 & <4)) & ((1-1.5) & (~1.5))");
+        Expression expr = parser.parse(">=1.0.1  <2 || 1 - 1.5");
         assertTrue(expr.interpret(Version.valueOf("1.5.0")));
         assertFalse(expr.interpret(Version.valueOf("2.5.0")));
     }
+
+
+    @Test
+    public void shouldParsePreReleaseExpression() {
+        ExpressionParser parser = new ExpressionParser(new Lexer());
+        Expression expr = parser.parse(">1.0.0-beta");
+        assertFalse(expr.interpret(Version.valueOf("1.0.0-alpha")));
+        assertTrue(expr.interpret(Version.valueOf("1.0.0-rc")));
+        assertTrue(expr.interpret(Version.valueOf("1.0.0")));
+    }
+
+    @Test
+    public void shouldParsePreReleaseExpressionWithParts() {
+        ExpressionParser parser = new ExpressionParser(new Lexer());
+        Expression expr = parser.parse(">1.0.0-beta.5");
+        assertFalse(expr.interpret(Version.valueOf("1.0.0-beta.1")));
+        assertTrue(expr.interpret(Version.valueOf("1.0.0-beta.6")));
+    }
+
 }

--- a/src/test/java/com/github/zafarkhaja/semver/expr/LexerTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/expr/LexerTest.java
@@ -52,18 +52,6 @@ public class LexerTest {
     }
 
     @Test
-    public void shouldSkipWhitespaces() {
-        Token[] expected = {
-            new Token(GREATER, ">",  0),
-            new Token(NUMERIC, "1",  2),
-            new Token(EOI,     null, 3),
-        };
-        Lexer lexer = new Lexer();
-        Stream<Token> stream = lexer.tokenize("> 1");
-        assertArrayEquals(expected, stream.toArray());
-    }
-
-    @Test
     public void shouldEndWithEol() {
         Token[] expected = {
             new Token(NUMERIC, "1",  0),

--- a/src/test/java/com/github/zafarkhaja/semver/expr/LexerTokenTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/expr/LexerTokenTest.java
@@ -80,7 +80,7 @@ public class LexerTokenTest {
 
         @Test
         public void shouldReturnFalseIfOtherVersionIsNull() {
-            Token t1 = new Token(AND, "&", 0);
+            Token t1 = new Token(OR, "||", 0);
             Token t2 = null;
             assertFalse(t1.equals(t2));
         }

--- a/src/test/java/com/github/zafarkhaja/semver/expr/ParserErrorHandlingTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/expr/ParserErrorHandlingTest.java
@@ -41,26 +41,21 @@ import static org.junit.Assert.*;
 public class ParserErrorHandlingTest {
 
     private final String invalidExpr;
-    private final Token unexpected;
-    private final Token.Type[] expected;
+    private final String unexpected;
 
     public ParserErrorHandlingTest(
-        String invalidExpr,
-        Token unexpected,
-        Token.Type[] expected
+        String invalidExpr, String unexpected
     ) {
         this.invalidExpr = invalidExpr;
-        this.unexpected  = unexpected;
-        this.expected    = expected;
+        this.unexpected = unexpected;
     }
 
     @Test
     public void shouldCorrectlyHandleParseErrors() {
         try {
             ExpressionParser.newInstance().parse(invalidExpr);
-        } catch (UnexpectedTokenException e) {
-            assertEquals(unexpected, e.getUnexpectedToken());
-            assertArrayEquals(expected, e.getExpectedTokenTypes());
+        } catch (LexerException e) {
+            assertEquals(unexpected, e.getExpr());
             return;
         }
         fail("Uncaught exception");
@@ -69,12 +64,12 @@ public class ParserErrorHandlingTest {
     @Parameters(name = "{0}")
     public static Collection<Object[]> parameters() {
         return Arrays.asList(new Object[][] {
-            { "1)",           new Token(RIGHT_PAREN, ")", 1),  new Token.Type[] { EOI } },
-            { "(>1.0.1",      new Token(EOI, null, 7),         new Token.Type[] { RIGHT_PAREN } },
-            { "((>=1 & <2)",  new Token(EOI, null, 11),        new Token.Type[] { RIGHT_PAREN } },
-            { ">=1.0.0 &",    new Token(EOI, null, 9),         new Token.Type[] { NUMERIC } },
-            { "(>2.0 |)",     new Token(RIGHT_PAREN, ")", 7),  new Token.Type[] { NUMERIC } },
-            { "& 1.2",        new Token(AND, "&", 0),          new Token.Type[] { NUMERIC } },
+            { "1)", ")"},
+            { "(>1.0.1","(>1.0.1"},
+            { "((>=1 & <2)", "((>=1 & <2)"},
+            { ">=1.0.0 &", "&"},
+            { "(>2.0 |)", "(>2.0 |)"},
+            { "& 1.2", "& 1.2"},
         });
     }
 }


### PR DESCRIPTION
Hi,
I had to change the expression parser to semver range as they are defined by :  
https://docs.npmjs.com/misc/semver#range-grammar
It's not really compatible with the one defined in https://github.com/zafarkhaja/jsemver/issues/1 - I replaced it, but maybe we could move the code in a separate implementation if you're interested to include it.
Regards
