### PR TITLE
Add ability to parse version without 3 increments (x.y.z)

### DIFF
--- a/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
+++ b/src/main/java/com/github/zafarkhaja/semver/VersionParser.java
@@ -200,28 +200,56 @@ class VersionParser implements Parser<Version> {
         VersionParser parser = new VersionParser(version);
         return parser.parseValidSemVer();
     }
-    
+
     /**
-     * Parses the whole version including pre-release version and build metadata.<br>
-     * Allow missing version increment. A missing increment is replaced by 0
+     * Parses the whole version including pre-release version and build metadata.<br> Allow version
+     * without MINOR and / or PATCH increment.
      *
      * @param version the version string to parse
      * @return a valid version object
      * @throws IllegalArgumentException if the input string is {@code NULL} or empty
      * @throws ParseException when there is a grammar error
      * @throws UnexpectedCharacterException when encounters an unexpected character type
+     * @see #parseCompatibleSemVer(String, MissingIncrementStrategy, MissingIncrementStrategy)
      */
     static Version parseCompatibleSemVer(String version) {
-        return parseCompatibleSemVer(version, DefaultValueMissingIncrementStrategy.ZERO, DefaultValueMissingIncrementStrategy.ZERO);
+        return parseCompatibleSemVer(version, DefaultValueMissingIncrementStrategy.ZERO,
+            DefaultValueMissingIncrementStrategy.ZERO);
     }
-    
-    static Version parseCompatibleSemVer(String version, MissingIncrementStrategy missingPatchStrategy) {
+
+    /**
+     * Parses the whole version including pre-release version and build metadata.
+     *
+     * @param version the version string to parse
+     * @param missingPatchStrategy strategy used on missing PATCH version increment
+     * @return a valid version object
+     * @throws IllegalArgumentException if the input string is {@code NULL} or empty
+     * @throws ParseException when there is a grammar error
+     * @throws UnexpectedCharacterException when encounters an unexpected character type
+     * @see #parseCompatibleSemVer(String, MissingIncrementStrategy, MissingIncrementStrategy)
+     */
+    static Version parseCompatibleSemVer(String version,
+        MissingIncrementStrategy missingPatchStrategy) {
         VersionParser parser = new VersionParser(version);
         parser.missingPatchStrategy = missingPatchStrategy;
         return parser.parseValidSemVer();
     }
-    
-    static Version parseCompatibleSemVer(String version, MissingIncrementStrategy missingPatchStrategy, MissingIncrementStrategy missingMinorStrategy) {
+
+    /**
+     * Parses the whole version including pre-release version and build metadata.
+     *
+     * @param version the version string to parse
+     * @param missingPatchStrategy strategy used on missing PATCH version increment
+     * @param missingMinorStrategy strategy used on missing MINOR version increment
+     * @return a valid version object
+     * @throws IllegalArgumentException if the input string is {@code NULL} or empty
+     * @throws ParseException when there is a grammar error
+     * @throws UnexpectedCharacterException when encounters an unexpected character type
+     * @see #parseCompatibleSemVer(String, MissingIncrementStrategy, MissingIncrementStrategy)
+     */
+    static Version parseCompatibleSemVer(String version,
+        MissingIncrementStrategy missingPatchStrategy,
+        MissingIncrementStrategy missingMinorStrategy) {
         VersionParser parser = new VersionParser(version);
         parser.missingPatchStrategy = missingPatchStrategy;
         parser.missingMinorStrategy = missingMinorStrategy;

--- a/src/main/java/com/github/zafarkhaja/semver/compatibility/DefaultValueMissingIncrementStrategy.java
+++ b/src/main/java/com/github/zafarkhaja/semver/compatibility/DefaultValueMissingIncrementStrategy.java
@@ -2,6 +2,9 @@ package com.github.zafarkhaja.semver.compatibility;
 
 import com.github.zafarkhaja.semver.ParseException;
 
+/**
+ * Strategy used to set missing increment to a default value.
+ */
 public class DefaultValueMissingIncrementStrategy implements MissingIncrementStrategy
 {
 	

--- a/src/main/java/com/github/zafarkhaja/semver/compatibility/DefaultValueMissingIncrementStrategy.java
+++ b/src/main/java/com/github/zafarkhaja/semver/compatibility/DefaultValueMissingIncrementStrategy.java
@@ -1,0 +1,20 @@
+package com.github.zafarkhaja.semver.compatibility;
+
+import com.github.zafarkhaja.semver.ParseException;
+
+public class DefaultValueMissingIncrementStrategy implements MissingIncrementStrategy
+{
+	
+	public static final MissingIncrementStrategy ZERO = new DefaultValueMissingIncrementStrategy(0);
+	
+	public final int defaultIncrement;
+	
+	private DefaultValueMissingIncrementStrategy(int defaultIncrement)
+	{
+		this.defaultIncrement = defaultIncrement;
+	}
+	
+	public int missingIncrementValue() throws ParseException {
+		return this.defaultIncrement;
+	}
+}

--- a/src/main/java/com/github/zafarkhaja/semver/compatibility/FailOnMissingIncrementStrategy.java
+++ b/src/main/java/com/github/zafarkhaja/semver/compatibility/FailOnMissingIncrementStrategy.java
@@ -1,0 +1,22 @@
+package com.github.zafarkhaja.semver.compatibility;
+
+import com.github.zafarkhaja.semver.ParseException;
+
+public class FailOnMissingIncrementStrategy implements MissingIncrementStrategy
+{
+	
+	public static final MissingIncrementStrategy MAJOR = new FailOnMissingIncrementStrategy("MAJOR");
+	public static final MissingIncrementStrategy MINOR = new FailOnMissingIncrementStrategy("MINOR");
+	public static final MissingIncrementStrategy PATCH = new FailOnMissingIncrementStrategy("PATCH");
+	
+	public final String increment;
+	
+	private FailOnMissingIncrementStrategy(String increment)
+	{
+		this.increment = increment;
+	}
+	
+	public int missingIncrementValue() throws ParseException {
+		throw new ParseException(this.increment+" increment is mandatory!");
+	}
+}

--- a/src/main/java/com/github/zafarkhaja/semver/compatibility/FailOnMissingIncrementStrategy.java
+++ b/src/main/java/com/github/zafarkhaja/semver/compatibility/FailOnMissingIncrementStrategy.java
@@ -2,6 +2,9 @@ package com.github.zafarkhaja.semver.compatibility;
 
 import com.github.zafarkhaja.semver.ParseException;
 
+/**
+ * Strategy used to throw an exception when an increment is missing.
+ */
 public class FailOnMissingIncrementStrategy implements MissingIncrementStrategy
 {
 	

--- a/src/main/java/com/github/zafarkhaja/semver/compatibility/MissingIncrementStrategy.java
+++ b/src/main/java/com/github/zafarkhaja/semver/compatibility/MissingIncrementStrategy.java
@@ -1,0 +1,8 @@
+package com.github.zafarkhaja.semver.compatibility;
+
+import com.github.zafarkhaja.semver.ParseException;
+
+public interface MissingIncrementStrategy
+{
+	int missingIncrementValue() throws ParseException;
+}

--- a/src/main/java/com/github/zafarkhaja/semver/compatibility/MissingIncrementStrategy.java
+++ b/src/main/java/com/github/zafarkhaja/semver/compatibility/MissingIncrementStrategy.java
@@ -2,7 +2,11 @@ package com.github.zafarkhaja.semver.compatibility;
 
 import com.github.zafarkhaja.semver.ParseException;
 
+/**
+ * Strategy can be implemented to interact when version increment is missing.
+ */
 public interface MissingIncrementStrategy
 {
+
 	int missingIncrementValue() throws ParseException;
 }

--- a/src/test/java/com/github/zafarkhaja/semver/CampatibleVersionParserTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/CampatibleVersionParserTest.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2012-2014 Zafar Khaja <zafarkhaja@gmail.com>.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.github.zafarkhaja.semver;
+
+import com.github.zafarkhaja.semver.compatibility.DefaultValueMissingIncrementStrategy;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Zafar Khaja <zafarkhaja@gmail.com>
+ */
+public class CampatibleVersionParserTest
+{
+	
+	@Test
+	public void shouldParseNormalVersion()
+	{
+		Version version = VersionParser.parseCompatibleSemVer("1.0.0");
+		Version expected = new Version(new NormalVersion(1, 0, 0), MetadataVersion.NULL);
+		assertEquals(expected, version);
+	}
+	
+	@Test
+	public void missingMajorRevision()
+	{
+		try {
+			VersionParser.parseCompatibleSemVer("alpha");
+		} catch (ParseException e) {
+			return;
+		}
+		fail("MAJOR increment is always mandatory!");
+	}
+	
+	@Test
+	public void allowMissingPatchRevision()
+	{
+		Version version = VersionParser.parseCompatibleSemVer("1.0", DefaultValueMissingIncrementStrategy.ZERO);
+		Version expected = new Version(new NormalVersion(1, 0, 0), MetadataVersion.NULL);
+		assertEquals(expected, version);
+	}
+	
+	@Test
+	public void allowMissingPatchRevisionFail()
+	{
+		try {
+			VersionParser.parseCompatibleSemVer("1", DefaultValueMissingIncrementStrategy.ZERO);
+		} catch (ParseException e) {
+			return;
+		}
+		fail("MINOR increment is required!");
+	}
+	
+	@Test
+	public void allowMissingMinorRevision()
+	{
+		Version version = VersionParser
+			.parseCompatibleSemVer("1", DefaultValueMissingIncrementStrategy.ZERO, DefaultValueMissingIncrementStrategy.ZERO);
+		Version expected = new Version(new NormalVersion(1, 0, 0), MetadataVersion.NULL);
+		assertEquals(expected, version);
+	}
+
+	
+}

--- a/src/test/java/com/github/zafarkhaja/semver/CompatibleVersionParserTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/CompatibleVersionParserTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.fail;
 /**
  * @author Zafar Khaja <zafarkhaja@gmail.com>
  */
-public class CampatibleVersionParserTest
+public class CompatibleVersionParserTest
 {
 	
 	@Test

--- a/src/test/java/com/github/zafarkhaja/semver/VersionParserTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionParserTest.java
@@ -37,6 +37,36 @@ public class VersionParserTest {
         NormalVersion version = VersionParser.parseVersionCore("1.0.0");
         assertEquals(new NormalVersion(1, 0, 0), version);
     }
+    
+    @Test
+    public void missingMajorRevision() {
+        try {
+            VersionParser.parseValidSemVer("alpha");
+        } catch (ParseException e) {
+            return;
+        }
+        fail("Missing major increment!");
+    }
+    
+    @Test
+    public void missingMinorRevision() {
+        try {
+            VersionParser.parseValidSemVer("1-alpha");
+        } catch (ParseException e) {
+            return;
+        }
+        fail("Missing patch increment!");
+    }
+    
+    @Test
+    public void missingPatchRevision() {
+        try {
+            VersionParser.parseValidSemVer("1.0-alpha");
+        } catch (ParseException e) {
+            return;
+        }
+        fail("Missing patch increment!");
+    }
 
     @Test
     public void shouldRaiseErrorIfNumericIdentifierHasLeadingZeroes() {
@@ -112,7 +142,7 @@ public class VersionParserTest {
             version
         );
     }
-
+    
     @Test
     public void shouldRaiseErrorForIllegalInputString() {
         for (String illegal : new String[] { "", null }) {


### PR DESCRIPTION
Hello,
I have added the ability to parse non-fully compatible versions like 1.0-SNAPSHOT because in our project we would like to use SemVer. But we have some legacy versions and we need to support them (while converting them to SemVer).

I added 3 methods parseCompatibleSemVer because parseValidSemVer should have valid input like the method explicitly says.

I added default strategies to handle missing increments with a replacement by 0 or an exception thrown. This allow to use customs strategies like log WARN and default with 0.