### PR TITLE
changes to the way versions are incremented to match how npm behaves.

### DIFF
--- a/src/main/java/com/github/zafarkhaja/semver/MetadataVersion.java
+++ b/src/main/java/com/github/zafarkhaja/semver/MetadataVersion.java
@@ -56,7 +56,7 @@ class MetadataVersion implements Comparable<MetadataVersion> {
          */
         @Override
         MetadataVersion increment() {
-            throw new NullPointerException("Metadata version is NULL");
+            return new MetadataVersion(new String[] {"0"});
         }
 
         /**
@@ -125,7 +125,7 @@ class MetadataVersion implements Comparable<MetadataVersion> {
             ids[ids.length - 1] = String.valueOf(++intId);
         } else {
             ids = Arrays.copyOf(ids, ids.length + 1);
-            ids[ids.length - 1] = String.valueOf(1);
+            ids[ids.length - 1] = String.valueOf(0);
         }
         return new MetadataVersion(ids);
     }

--- a/src/main/java/com/github/zafarkhaja/semver/Version.java
+++ b/src/main/java/com/github/zafarkhaja/semver/Version.java
@@ -345,7 +345,7 @@ public class Version implements Comparable<Version> {
      * @return a new instance of the {@code Version} class
      */
     public Version incrementMajorVersion() {
-        if (preRelease == MetadataVersion.NULL) {
+        if (preRelease == MetadataVersion.NULL || normal.getPatch() != 0 || normal.getMinor() != 0) {
             return new Version(normal.incrementMajor());
         }
         return new Version(normal);
@@ -377,7 +377,7 @@ public class Version implements Comparable<Version> {
      * @return a new instance of the {@code Version} class
      */
     public Version incrementMinorVersion() {
-        if (preRelease == MetadataVersion.NULL) {            
+        if (preRelease == MetadataVersion.NULL || normal.getPatch() != 0) {
             return new Version(normal.incrementMinor());
         }
         return new Version(normal);

--- a/src/main/java/com/github/zafarkhaja/semver/Version.java
+++ b/src/main/java/com/github/zafarkhaja/semver/Version.java
@@ -345,7 +345,14 @@ public class Version implements Comparable<Version> {
      * @return a new instance of the {@code Version} class
      */
     public Version incrementMajorVersion() {
-        return new Version(normal.incrementMajor());
+        if (preRelease == MetadataVersion.NULL) {
+            return new Version(normal.incrementMajor());
+        }
+        return new Version(normal);
+    }
+
+    public Version incrementPreMajorVersion() {
+        return incrementMajorVersion("0");
     }
 
     /**
@@ -370,7 +377,19 @@ public class Version implements Comparable<Version> {
      * @return a new instance of the {@code Version} class
      */
     public Version incrementMinorVersion() {
-        return new Version(normal.incrementMinor());
+        if (preRelease == MetadataVersion.NULL) {            
+            return new Version(normal.incrementMinor());
+        }
+        return new Version(normal);
+    }
+
+    /**
+     * Increments the minor version.
+     *
+     * @return a new instance of the {@code Version} class
+     */
+    public Version incrementPreMinorVersion() {
+        return incrementMinorVersion("0");
     }
 
     /**
@@ -395,7 +414,13 @@ public class Version implements Comparable<Version> {
      * @return a new instance of the {@code Version} class
      */
     public Version incrementPatchVersion() {
-        return new Version(normal.incrementPatch());
+        if (preRelease == MetadataVersion.NULL)
+            return new Version(normal.incrementPatch());
+        return new Version(normal);
+    }
+
+    public Version incrementPrePatchVersion() {
+        return incrementPatchVersion("0");
     }
 
     /**

--- a/src/test/java/com/github/zafarkhaja/semver/MetadataVersionTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/MetadataVersionTest.java
@@ -118,7 +118,7 @@ public class MetadataVersionTest {
                 new String[] {"alpha"}
             );
             MetadataVersion v2 = v1.increment();
-            assertEquals("alpha.1", v2.toString());
+            assertEquals("alpha.0", v2.toString());
         }
 
         @Test
@@ -171,12 +171,8 @@ public class MetadataVersionTest {
 
         @Test
         public void shouldThrowNullPointerExceptionIfIncremented() {
-            try {
-                MetadataVersion.NULL.increment();
-            } catch (NullPointerException e) {
-                return;
-            }
-            fail("Should throw NullPointerException when incremented");
+            MetadataVersion v2 = MetadataVersion.NULL.increment();
+            assertEquals("0", v2.toString());
         }
     }
 

--- a/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
@@ -195,19 +195,25 @@ public class VersionTest {
             Version v = Version.valueOf("1.2.3-alpha+build");
 
             Version major1 = v.incrementMajorVersion();
-            assertEquals("2.0.0", major1.toString());
+            assertEquals("1.2.3", major1.toString());
             Version major2 = v.incrementMajorVersion("beta");
             assertEquals("2.0.0-beta", major2.toString());
+            Version major3 = v.incrementPreMajorVersion();
+            assertEquals("2.0.0-0", major3.toString());
 
             Version minor1 = v.incrementMinorVersion();
-            assertEquals("1.3.0", minor1.toString());
+            assertEquals("1.2.3", minor1.toString());
             Version minor2 = v.incrementMinorVersion("beta");
             assertEquals("1.3.0-beta", minor2.toString());
+            Version minor3 = v.incrementPreMinorVersion();
+            assertEquals("1.3.0-0", minor3.toString());
 
             Version patch1 = v.incrementPatchVersion();
-            assertEquals("1.2.4", patch1.toString());
+            assertEquals("1.2.3", patch1.toString());
             Version patch2 = v.incrementPatchVersion("beta");
             assertEquals("1.2.4-beta", patch2.toString());
+            Version patch3 = v.incrementPrePatchVersion();
+            assertEquals("1.2.4-0", patch3.toString());
         }
 
         @Test
@@ -241,12 +247,8 @@ public class VersionTest {
         @Test
         public void shouldThrowExceptionWhenIncrementingPreReleaseIfItsNull() {
             Version v1 = Version.valueOf("1.0.0");
-            try {
-                v1.incrementPreReleaseVersion();
-            } catch (NullPointerException e) {
-                return;
-            }
-            fail("Method was expected to throw NullPointerException");
+            Version v2 = v1.incrementPreReleaseVersion();
+            assertEquals("1.0.0-0", v2.toString());
         }
 
         @Test
@@ -266,12 +268,8 @@ public class VersionTest {
         @Test
         public void shouldThrowExceptionWhenIncrementingBuildIfItsNull() {
             Version v1 = Version.valueOf("1.0.0");
-            try {
-                v1.incrementBuildMetadata();
-            } catch (NullPointerException e) {
-                return;
-            }
-            fail("Method was expected to throw NullPointerException");
+            Version v2 = v1.incrementBuildMetadata();
+            assertEquals("1.0.0+0", v2.toString());
         }
 
         @Test

--- a/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
+++ b/src/test/java/com/github/zafarkhaja/semver/VersionTest.java
@@ -195,14 +195,14 @@ public class VersionTest {
             Version v = Version.valueOf("1.2.3-alpha+build");
 
             Version major1 = v.incrementMajorVersion();
-            assertEquals("1.2.3", major1.toString());
+            assertEquals("2.0.0", major1.toString());
             Version major2 = v.incrementMajorVersion("beta");
             assertEquals("2.0.0-beta", major2.toString());
             Version major3 = v.incrementPreMajorVersion();
             assertEquals("2.0.0-0", major3.toString());
 
             Version minor1 = v.incrementMinorVersion();
-            assertEquals("1.2.3", minor1.toString());
+            assertEquals("1.3.0", minor1.toString());
             Version minor2 = v.incrementMinorVersion("beta");
             assertEquals("1.3.0-beta", minor2.toString());
             Version minor3 = v.incrementPreMinorVersion();
@@ -214,6 +214,36 @@ public class VersionTest {
             assertEquals("1.2.4-beta", patch2.toString());
             Version patch3 = v.incrementPrePatchVersion();
             assertEquals("1.2.4-0", patch3.toString());
+        }
+
+        @Test
+        public void shouldDropPreMetadataWhenIncrementingWithZero() {
+            Version major = Version.valueOf("1.0.0-alpha");
+
+            Version major1 = major.incrementMajorVersion();
+            assertEquals("1.0.0", major1.toString());
+            Version major2 = major.incrementMinorVersion();
+            assertEquals("1.0.0", major2.toString());
+            Version major3 = major.incrementPatchVersion();
+            assertEquals("1.0.0", major3.toString());
+
+            Version minor = Version.valueOf("1.2.0-alpha");
+
+            Version minor1 = minor.incrementMajorVersion();
+            assertEquals("2.0.0", minor1.toString());
+            Version minor2 = minor.incrementMinorVersion();
+            assertEquals("1.2.0", minor2.toString());
+            Version minor3 = minor.incrementPatchVersion();
+            assertEquals("1.2.0", minor3.toString());
+
+            Version patch = Version.valueOf("1.2.3-alpha");
+
+            Version patch1 = patch.incrementMajorVersion();
+            assertEquals("2.0.0", patch1.toString());
+            Version patch2 = patch.incrementMinorVersion();
+            assertEquals("1.3.0", patch2.toString());
+            Version patch3 = patch.incrementPatchVersion();
+            assertEquals("1.2.3", patch3.toString());
         }
 
         @Test


### PR DESCRIPTION
Users of our app were noticing that the way it increments versions with and without prerelease metadata was different from how `npm version <inc type>` behaves.

with the input `1.2.3-pre.1+build.1` the command `npm version patch` produces `1.2.3` but this library produces `1.2.4`.

@srinivasankavitha